### PR TITLE
Enable music sharing through a GridItemAdapter's long click

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,9 +12,9 @@ android {
         namespace 'com.tiefensuche.soundcrowd'
         applicationId 'com.tiefensuche.soundcrowd'
         versionName "3.6.1"
-        compileSdk 34
-        minSdkVersion 16
-        targetSdkVersion 34
+        compileSdk 35
+        minSdkVersion 21
+        targetSdkVersion 35
         versionCode 76
         proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
@@ -51,11 +51,11 @@ dependencies {
 
     // android support
     // material 1.12.0 requires minSdk 19
-    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.palette:palette-ktx:1.0.0'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     // exoplayer 1.3.0 requires minSdk 19
-    implementation "androidx.media3:media3-exoplayer:1.2.1"
+    implementation "androidx.media3:media3-exoplayer:1.5.1"
 
     // other third party
     implementation 'com.github.bumptech.glide:glide:4.14.2'

--- a/app/src/main/java/com/tiefensuche/soundcrowd/service/MusicService.kt
+++ b/app/src/main/java/com/tiefensuche/soundcrowd/service/MusicService.kt
@@ -329,6 +329,11 @@ internal class MusicService : MediaBrowserServiceCompat(), PlaybackManager.Playb
     }
 
     companion object {
+        // The function allowing looking up non-playable music metadata through
+        // the usage of the MusicProvider
+        fun getMusic(musicId : String) : MediaMetadataCompat? {
+            return mMusicProvider.getMusic(musicId)
+        }
 
         // The action of the incoming Intent indicating that it contains a command
         // to be executed (see {@link #onStartCommand})

--- a/app/src/main/java/com/tiefensuche/soundcrowd/service/Share.kt
+++ b/app/src/main/java/com/tiefensuche/soundcrowd/service/Share.kt
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package com.tiefensuche.soundcrowd.service
+
+import android.content.Context
+import android.content.Intent
+import com.tiefensuche.soundcrowd.R
+import com.tiefensuche.soundcrowd.ui.BaseActivity.Companion.MIME_TEXT
+
+/**
+ * A simple helper class for sharing content through the Intent.ACTION_SEND paradigm
+ */
+class Share {
+    companion object {
+        private val sharingIntent = Intent(Intent.ACTION_SEND)
+
+        fun shareText(rootViewContext : Context, textToShare: String) {
+            sharingIntent.type = MIME_TEXT
+            sharingIntent.putExtra(Intent.EXTRA_TEXT, textToShare)
+            rootViewContext.startActivity(Intent.createChooser(sharingIntent, rootViewContext.resources.getString(
+                R.string.share_via)))
+        }
+    }
+}

--- a/app/src/main/java/com/tiefensuche/soundcrowd/sources/LocalSource.kt
+++ b/app/src/main/java/com/tiefensuche/soundcrowd/sources/LocalSource.kt
@@ -46,7 +46,7 @@ internal class LocalSource(private val context: MusicService) {
                 .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, duration)
                 .putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ART_URI, uri.toString())
                 .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
-                .putString(MediaMetadataCompatExt.METADATA_KEY_SOURCE, name)
+                .putString(MediaMetadataCompatExt.METADATA_KEY_SOURCE, NAME)
                 .build()
     }
 
@@ -94,7 +94,7 @@ internal class LocalSource(private val context: MusicService) {
                             .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, duration)
                             .putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ART_URI, trackUri.toString())
                             .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
-                            .putString(MediaMetadataCompatExt.METADATA_KEY_SOURCE, name)
+                            .putString(MediaMetadataCompatExt.METADATA_KEY_SOURCE, NAME)
                             .build())
                 } catch (e: Exception) {
                     Log.w(TAG, "error while processing track", e)
@@ -114,7 +114,7 @@ internal class LocalSource(private val context: MusicService) {
     }
 
     companion object {
-        const val name = "Local"
+        const val NAME = "Local"
         private val TAG = LocalSource::class.simpleName
     }
 }

--- a/app/src/main/java/com/tiefensuche/soundcrowd/sources/MusicProvider.kt
+++ b/app/src/main/java/com/tiefensuche/soundcrowd/sources/MusicProvider.kt
@@ -250,7 +250,7 @@ internal class MusicProvider(context: MusicService) {
     ) {
         getMusic(extractMusicIDFromMediaID(mediaId))?.let { metadata ->
             val source = metadata.getString(MediaMetadataCompatExt.METADATA_KEY_SOURCE)
-            if (source == LocalSource.name) {
+            if (source == LocalSource.NAME) {
                 callback.onResult(Pair(metadata, null))
                 return
             }

--- a/app/src/main/java/com/tiefensuche/soundcrowd/ui/FullScreenPlayerFragment.kt
+++ b/app/src/main/java/com/tiefensuche/soundcrowd/ui/FullScreenPlayerFragment.kt
@@ -57,10 +57,10 @@ import com.tiefensuche.soundcrowd.images.GlideRequests
 import com.tiefensuche.soundcrowd.playback.PlaybackManager.Companion.CUSTOM_ACTION_ADD_CUE_POINT
 import com.tiefensuche.soundcrowd.playback.PlaybackManager.Companion.CUSTOM_ACTION_REMOVE_CUE_POINT
 import com.tiefensuche.soundcrowd.playback.PlaybackManager.Companion.CUSTOM_ACTION_SET_CUE_POINT
+import com.tiefensuche.soundcrowd.service.Share
 import com.tiefensuche.soundcrowd.sources.MusicProvider.Companion.MEDIA_ID
 import com.tiefensuche.soundcrowd.sources.MusicProvider.Cues.DESCRIPTION
 import com.tiefensuche.soundcrowd.sources.MusicProvider.Cues.POSITION
-import com.tiefensuche.soundcrowd.ui.BaseActivity.Companion.MIME_TEXT
 import com.tiefensuche.soundcrowd.ui.intro.ShowcaseViewManager
 import com.tiefensuche.soundcrowd.utils.Utils
 import com.tiefensuche.soundcrowd.waveform.WaveformHandler
@@ -228,12 +228,9 @@ internal class FullScreenPlayerFragment : Fragment() {
 
         mShare = rootView.findViewById(R.id.share)
         mShare.setOnClickListener {
-            mCurrentMetadata?.let {
-                val sharingIntent = Intent(Intent.ACTION_SEND)
+            mCurrentMetadata?.let { it ->
                 it.getString(MediaMetadataCompatExt.METADATA_KEY_URL)?.let {
-                    sharingIntent.type = MIME_TEXT
-                    sharingIntent.putExtra(Intent.EXTRA_TEXT, it)
-                    startActivity(Intent.createChooser(sharingIntent, getString(R.string.share_via)))
+                    Share.shareText(rootView.context, it)
                 }
             }
         }

--- a/app/src/main/java/com/tiefensuche/soundcrowd/ui/GridItemAdapter.kt
+++ b/app/src/main/java/com/tiefensuche/soundcrowd/ui/GridItemAdapter.kt
@@ -10,12 +10,14 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.tiefensuche.soundcrowd.R
 import com.tiefensuche.soundcrowd.extensions.MediaMetadataCompatExt
 import com.tiefensuche.soundcrowd.images.ArtworkHelper
 import com.tiefensuche.soundcrowd.images.GlideApp
 import com.tiefensuche.soundcrowd.images.GlideRequests
+import com.tiefensuche.soundcrowd.service.Share
+import com.tiefensuche.soundcrowd.service.MusicService
+import com.tiefensuche.soundcrowd.utils.MediaIDHelper.extractMusicIDFromMediaID
 
 internal class GridItemAdapter(private val requests: GlideRequests, private val listener: OnItemClickListener, private val defaultColor: Int) : MediaItemAdapter<GridItemAdapter.ViewHolder>() {
 
@@ -81,12 +83,21 @@ internal class GridItemAdapter(private val requests: GlideRequests, private val 
         var mediaItem = 0
 
         init {
+            // Play on clicking
             holder.setOnClickListener { listener.onItemClick(mDataset[mediaItem]) }
+
+            // Open the sharing board on long clicking
             holder.setOnLongClickListener {
-                MaterialAlertDialogBuilder(parentContext)
-                    .setTitle("test")
-                    .setMessage("copied")
-                    .show()
+                mDataset[mediaItem].description.mediaId?.let { mediaId ->
+                    val metadata : MediaMetadataCompat? = MusicService.getMusic(extractMusicIDFromMediaID(mediaId))
+
+                    if (metadata != null) {
+                        metadata.getString(MediaMetadataCompatExt.METADATA_KEY_URL)?.let {url ->
+                            Share.shareText(holder.context, url)
+                        }
+                    }
+                }
+
                 return@setOnLongClickListener true
             }
         }

--- a/app/src/main/java/com/tiefensuche/soundcrowd/ui/GridItemAdapter.kt
+++ b/app/src/main/java/com/tiefensuche/soundcrowd/ui/GridItemAdapter.kt
@@ -24,7 +24,7 @@ internal class GridItemAdapter(private val requests: GlideRequests, private val 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val convertView = LayoutInflater.from(parent.context)
             .inflate(R.layout.media_grid_item, parent, false)
-        return ViewHolder(convertView, parent.context)
+        return ViewHolder(convertView)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -72,7 +72,7 @@ internal class GridItemAdapter(private val requests: GlideRequests, private val 
         holder.mDuration.setTextColor(text)
     }
 
-    inner class ViewHolder internal constructor(holder: View, parentContext: Context) : RecyclerView.ViewHolder(holder) {
+    inner class ViewHolder internal constructor(holder: View) : RecyclerView.ViewHolder(holder) {
 
         val mBackground: ImageView = holder.findViewById(R.id.background)
         val mImageViewArtwork: ImageView = holder.findViewById(R.id.album_art)

--- a/app/src/main/java/com/tiefensuche/soundcrowd/ui/GridItemAdapter.kt
+++ b/app/src/main/java/com/tiefensuche/soundcrowd/ui/GridItemAdapter.kt
@@ -1,5 +1,6 @@
 package com.tiefensuche.soundcrowd.ui
 
+import android.content.Context
 import android.graphics.Color
 import android.support.v4.media.MediaMetadataCompat
 import android.text.format.DateUtils
@@ -9,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.tiefensuche.soundcrowd.R
 import com.tiefensuche.soundcrowd.extensions.MediaMetadataCompatExt
 import com.tiefensuche.soundcrowd.images.ArtworkHelper
@@ -20,7 +22,7 @@ internal class GridItemAdapter(private val requests: GlideRequests, private val 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val convertView = LayoutInflater.from(parent.context)
             .inflate(R.layout.media_grid_item, parent, false)
-        return ViewHolder(convertView)
+        return ViewHolder(convertView, parent.context)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -68,7 +70,7 @@ internal class GridItemAdapter(private val requests: GlideRequests, private val 
         holder.mDuration.setTextColor(text)
     }
 
-    inner class ViewHolder internal constructor(holder: View) : RecyclerView.ViewHolder(holder) {
+    inner class ViewHolder internal constructor(holder: View, parentContext: Context) : RecyclerView.ViewHolder(holder) {
 
         val mBackground: ImageView = holder.findViewById(R.id.background)
         val mImageViewArtwork: ImageView = holder.findViewById(R.id.album_art)
@@ -80,6 +82,13 @@ internal class GridItemAdapter(private val requests: GlideRequests, private val 
 
         init {
             holder.setOnClickListener { listener.onItemClick(mDataset[mediaItem]) }
+            holder.setOnLongClickListener {
+                MaterialAlertDialogBuilder(parentContext)
+                    .setTitle("test")
+                    .setMessage("copied")
+                    .show()
+                return@setOnLongClickListener true
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,6 @@
 // all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '8.7.1' apply false
+    id 'com.android.application' version '8.8.0' apply false
     id 'org.jetbrains.kotlin.android' version '2.0.21' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -20,4 +20,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip


### PR DESCRIPTION
nabend!

I'm a real enjoyer of your application and I thought it was missing the option to share non-local content directly from the grid view, ie: without starting the music and opening up the Fragment to find the share button.

I hope these changes can find their way into the official build of the application. I also updated some dependencies and gradle build files as they were getting old and I figured why not.

**Old behavior:**
Long press on a grid item: nothing

**New behavior:**
Long press on a grid item:

- if local: nothing
- if distant (plugin usage): pops up the ACTION_SEND intent for link copying/sending

This has been tested on my side with the Soundcloud plugin.

